### PR TITLE
Adjust gallery ratio and contact section

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     }
     #galeria img {
       height: 16rem;
-      width: auto;
+      width: calc(16rem * 4 / 3);
       object-fit: cover;
       border-radius: 0.5rem;
       box-shadow: 0 10px 15px rgba(0, 0, 0, 0.5);
@@ -33,7 +33,7 @@
       padding-bottom: 3rem;
     }
     #galeria .swiper-slide {
-      width: 250px;
+      width: calc(16rem * 4 / 3);
     }
   </style>
 </head>
@@ -163,17 +163,38 @@
           <textarea placeholder="Mensaje" class="w-full p-3 border rounded h-32"></textarea>
           <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Enviar</button>
         </form>
-        <div class="mt-8 space-y-2">
-          <p><strong>Dirección:</strong> Carlos Barrón 102, Colonia Altavista, Aguascalientes</p>
-          <p><strong>WhatsApp:</strong> <a href="https://wa.me/524499078497?text=Información%20sobre%20CTEV" class="text-blue-600 hover:underline">+52 449 907 8497</a></p>
-          <p><strong>Correo:</strong> <a href="mailto:victima_01@hotmail.com" class="text-blue-600 hover:underline">victima_01@hotmail.com</a></p>
-        </div>
       </div>
       <div class="flex items-center justify-center">
         <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d326.388919079444!2d-102.30483034126343!3d21.89468767404594!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x8429ef2a4b4151fd%3A0x6ca254f5e20d0919!2sConstruccion%20Topografia%20y%20Equipo%20Vial!5e1!3m2!1ses-419!2smx!4v1751564165037!5m2!1ses-419!2smx" width="600" height="450" style="border:0;" allowfullscreen loading="lazy" referrerpolicy="no-referrer-when-downgrade" class="w-full h-72 rounded-lg shadow-lg"></iframe>
       </div>
     </div>
   </section>
+
+<section id="info-contacto" class="bg-gray-100 pb-16 px-6" data-aos="fade-up">
+  <div class="max-w-5xl mx-auto grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
+    <div class="flex items-start">
+      <svg class="h-6 w-6 text-blue-600" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M15 10.5C15 12.1569 13.6569 13.5 12 13.5C10.3431 13.5 9 12.1569 9 10.5C9 8.84315 10.3431 7.5 12 7.5C13.6569 7.5 15 8.84315 15 10.5Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M19.5 10.5C19.5 17.6421 12 21.75 12 21.75C12 21.75 4.5 17.6421 4.5 10.5C4.5 6.35786 7.85786 3 12 3C16.1421 3 19.5 6.35786 19.5 10.5Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+      <span class="ml-2">Carlos Barrón 102, Colonia Altavista, Aguascalientes</span>
+    </div>
+    <div class="flex items-start">
+      <svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-green-600"><title>WhatsApp</title><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .165 5.335.162 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.893-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z"/></svg>
+      <a href="https://wa.me/524499078497?text=Información%20sobre%20CTEV" class="ml-2 text-blue-600 hover:underline">+52 449 907 8497</a>
+    </div>
+    <div class="flex items-start">
+      <svg class="h-6 w-6 text-blue-600" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M21.75 6.75V17.25C21.75 18.4926 20.7426 19.5 19.5 19.5H4.5C3.25736 19.5 2.25 18.4926 2.25 17.25V6.75M21.75 6.75C21.75 5.50736 20.7426 4.5 19.5 4.5H4.5C3.25736 4.5 2.25 5.50736 2.25 6.75M21.75 6.75V6.99271C21.75 7.77405 21.3447 8.49945 20.6792 8.90894L13.1792 13.5243C12.4561 13.9694 11.5439 13.9694 10.8208 13.5243L3.32078 8.90894C2.65535 8.49945 2.25 7.77405 2.25 6.99271V6.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+      <a href="mailto:victima_01@hotmail.com" class="ml-2 text-blue-600 hover:underline">victima_01@hotmail.com</a>
+    </div>
+    <div class="flex items-start">
+      <svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-blue-600"><title>Facebook</title><path d="M9.101 23.691v-7.98H6.627v-3.667h2.474v-1.58c0-4.085 1.848-5.978 5.858-5.978.401 0 .955.042 1.468.103a8.68 8.68 0 0 1 1.141.195v3.325a8.623 8.623 0 0 0-.653-.036 26.805 26.805 0 0 0-.733-.009c-.707 0-1.259.096-1.675.309a1.686 1.686 0 0 0-.679.622c-.258.42-.374.995-.374 1.752v1.297h3.919l-.386 2.103-.287 1.564h-3.246v8.245C19.396 23.238 24 18.179 24 12.044c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.628 3.874 10.35 9.101 11.647Z"/></svg>
+      <a href="https://www.facebook.com/profile.php?id=100064368954991" class="ml-2 text-blue-600 hover:underline">Facebook</a>
+    </div>
+  </div>
+</section>
 
   <footer class="bg-gray-800 text-white text-center py-4">
     © 2025 Construcción, Topografía y Equipo Vial. Todos los derechos reservados.


### PR DESCRIPTION
## Summary
- keep gallery previews at a 4:3 ratio
- move contact details into their own section with icons
- include Facebook link

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866edc8980083259e40f6968ba80992