### PR TITLE
Fix hero text single line

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
   <section id="inicio" class="hero-bg min-h-screen flex items-center justify-center pt-24 px-4" data-aos="fade-in">
     <div class="bg-white rounded-lg shadow-2xl p-4 w-full max-w-sm mx-auto flex flex-col items-center justify-center">
       <img src="CTEV - Logo single.png" alt="CTEV Logo" class="w-full h-full object-contain">
-      <h1 class="hero-text text-xl mt-2 text-center">CONSTRUCCIÓN, TOPOGRAFÍA Y EQUIPO VIAL</h1>
+      <h1 class="hero-text text-xs sm:text-base md:text-lg lg:text-xl mt-2 text-center whitespace-nowrap">CONSTRUCCIÓN, TOPOGRAFÍA Y EQUIPO VIAL</h1>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- keep hero slogan on a single line across viewports
- reduce hero slogan size for mobile

## Testing
- `tidy -q -e index.html`

------
https://chatgpt.com/codex/tasks/task_e_6866fea05c1083258dada13c9bf8b508